### PR TITLE
Fixed missing braces in ViewController.swift

### DIFF
--- a/Atari-Breakout/ViewController.swift
+++ b/Atari-Breakout/ViewController.swift
@@ -175,3 +175,5 @@ class ViewController: UIViewController, UICollisionBehaviorDelegate {
                 
             }
         }
+    }
+}


### PR DESCRIPTION
There were two missing braces at the end of the file, which caused a error at build time.